### PR TITLE
fix: authentication flow

### DIFF
--- a/public/silent-check-sso.html
+++ b/public/silent-check-sso.html
@@ -1,0 +1,7 @@
+<html>
+  <body>
+    <script>
+      parent.postMessage(location.href, location.origin);
+    </script>
+  </body>
+</html>

--- a/public/silent-check-sso.html
+++ b/public/silent-check-sso.html
@@ -1,7 +1,0 @@
-<html>
-  <body>
-    <script>
-      parent.postMessage(location.href, location.origin);
-    </script>
-  </body>
-</html>

--- a/src/components/nav-bar/nav-bar.tsx
+++ b/src/components/nav-bar/nav-bar.tsx
@@ -26,7 +26,7 @@ const NavItems: NavItem[] = [
 ];
 
 export function NavBar() {
-	const { isAuthenticated, loading, login, logout } = useContext(AuthContext);
+	const { isAuthenticated, login, logout } = useContext(AuthContext);
 
 	return (
 		<nav className="flex w-full justify-between py-4">
@@ -44,7 +44,7 @@ export function NavBar() {
 
 				<div className="flex items-center gap-6">
 					<ul className="flex items-center gap-4">
-						{!loading && !isAuthenticated ? null : (
+						{isAuthenticated && (
 							<Button
 								variant="secondary"
 								className={cn(
@@ -63,20 +63,7 @@ export function NavBar() {
 								pageName={it.pageName}
 							/>
 						))}
-						{!loading && !isAuthenticated ? (
-							<Button
-								onClick={() => {
-									console.log("LOGIN CLICKED");
-									login();
-								}}
-								className={cn(
-									"text-md",
-									"h-10 rounded-md px-4 has-[>svg]:px-4"
-								)}
-							>
-								Login
-							</Button>
-						) : (
+						{isAuthenticated ? (
 							<Button
 								onClick={logout}
 								variant="destructive"
@@ -86,6 +73,16 @@ export function NavBar() {
 								)}
 							>
 								Logout
+							</Button>
+						) : (
+							<Button
+								onClick={login}
+								className={cn(
+									"text-md",
+									"h-10 rounded-md px-4 has-[>svg]:px-4"
+								)}
+							>
+								Login
 							</Button>
 						)}
 					</ul>

--- a/src/hooks/use-user.ts
+++ b/src/hooks/use-user.ts
@@ -2,9 +2,10 @@ import { useQuery } from "@tanstack/react-query";
 import { getMe } from "@/lib/auth-client";
 import type { MeResponse } from "@/lib/types";
 
-export function useUser() {
+export function useUser(enabled: boolean = true) {
 	return useQuery<MeResponse>({
 		queryKey: ["me"],
 		queryFn: getMe,
+		enabled,
 	});
 }

--- a/src/providers/keycloak-provider.tsx
+++ b/src/providers/keycloak-provider.tsx
@@ -13,6 +13,7 @@ export function KeycloakProvider({ children }: { children: React.ReactNode }) {
 				onLoad: "check-sso",
 				pkceMethod: "S256",
 				checkLoginIframe: false,
+				silentCheckSsoRedirectUri: `${window.location.origin}/silent-check-sso.html`,
 			})
 			.then((authenticated) => {
 				setIsAuthenticated(authenticated);

--- a/src/providers/keycloak-provider.tsx
+++ b/src/providers/keycloak-provider.tsx
@@ -13,7 +13,7 @@ export function KeycloakProvider({ children }: { children: React.ReactNode }) {
 				onLoad: "check-sso",
 				pkceMethod: "S256",
 				checkLoginIframe: false,
-				silentCheckSsoRedirectUri: `${window.location.origin}/silent-check-sso.html`,
+				silentCheckSsoRedirectUri: `${window.location.origin}/silent-check-sso`,
 			})
 			.then((authenticated) => {
 				setIsAuthenticated(authenticated);

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -10,6 +10,7 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as TermsOfUseRouteImport } from './routes/terms-of-use'
+import { Route as SilentCheckSsoRouteImport } from './routes/silent-check-sso'
 import { Route as ResourcesRouteImport } from './routes/resources'
 import { Route as PublicDataRouteImport } from './routes/public-data'
 import { Route as PrivacyPolicyRouteImport } from './routes/privacy-policy'
@@ -25,6 +26,11 @@ import { Route as ProjectsProjectIdRouteImport } from './routes/projects/$projec
 const TermsOfUseRoute = TermsOfUseRouteImport.update({
   id: '/terms-of-use',
   path: '/terms-of-use',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const SilentCheckSsoRoute = SilentCheckSsoRouteImport.update({
+  id: '/silent-check-sso',
+  path: '/silent-check-sso',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ResourcesRoute = ResourcesRouteImport.update({
@@ -90,6 +96,7 @@ export interface FileRoutesByFullPath {
   '/privacy-policy': typeof PrivacyPolicyRoute
   '/public-data': typeof PublicDataRoute
   '/resources': typeof ResourcesRoute
+  '/silent-check-sso': typeof SilentCheckSsoRoute
   '/terms-of-use': typeof TermsOfUseRoute
   '/projects/$projectId': typeof ProjectsProjectIdRoute
   '/projects/my-profile': typeof ProjectsMyProfileRoute
@@ -103,6 +110,7 @@ export interface FileRoutesByTo {
   '/privacy-policy': typeof PrivacyPolicyRoute
   '/public-data': typeof PublicDataRoute
   '/resources': typeof ResourcesRoute
+  '/silent-check-sso': typeof SilentCheckSsoRoute
   '/terms-of-use': typeof TermsOfUseRoute
   '/projects/$projectId': typeof ProjectsProjectIdRoute
   '/projects/my-profile': typeof ProjectsMyProfileRoute
@@ -118,6 +126,7 @@ export interface FileRoutesById {
   '/privacy-policy': typeof PrivacyPolicyRoute
   '/public-data': typeof PublicDataRoute
   '/resources': typeof ResourcesRoute
+  '/silent-check-sso': typeof SilentCheckSsoRoute
   '/terms-of-use': typeof TermsOfUseRoute
   '/projects/$projectId': typeof ProjectsProjectIdRoute
   '/projects/my-profile': typeof ProjectsMyProfileRoute
@@ -134,6 +143,7 @@ export interface FileRouteTypes {
     | '/privacy-policy'
     | '/public-data'
     | '/resources'
+    | '/silent-check-sso'
     | '/terms-of-use'
     | '/projects/$projectId'
     | '/projects/my-profile'
@@ -147,6 +157,7 @@ export interface FileRouteTypes {
     | '/privacy-policy'
     | '/public-data'
     | '/resources'
+    | '/silent-check-sso'
     | '/terms-of-use'
     | '/projects/$projectId'
     | '/projects/my-profile'
@@ -161,6 +172,7 @@ export interface FileRouteTypes {
     | '/privacy-policy'
     | '/public-data'
     | '/resources'
+    | '/silent-check-sso'
     | '/terms-of-use'
     | '/projects/$projectId'
     | '/projects/my-profile'
@@ -176,6 +188,7 @@ export interface RootRouteChildren {
   PrivacyPolicyRoute: typeof PrivacyPolicyRoute
   PublicDataRoute: typeof PublicDataRoute
   ResourcesRoute: typeof ResourcesRoute
+  SilentCheckSsoRoute: typeof SilentCheckSsoRoute
   TermsOfUseRoute: typeof TermsOfUseRoute
   AboutIndexRoute: typeof AboutIndexRoute
   HelpAndSupportIndexRoute: typeof HelpAndSupportIndexRoute
@@ -188,6 +201,13 @@ declare module '@tanstack/react-router' {
       path: '/terms-of-use'
       fullPath: '/terms-of-use'
       preLoaderRoute: typeof TermsOfUseRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/silent-check-sso': {
+      id: '/silent-check-sso'
+      path: '/silent-check-sso'
+      fullPath: '/silent-check-sso'
+      preLoaderRoute: typeof SilentCheckSsoRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/resources': {
@@ -293,6 +313,7 @@ const rootRouteChildren: RootRouteChildren = {
   PrivacyPolicyRoute: PrivacyPolicyRoute,
   PublicDataRoute: PublicDataRoute,
   ResourcesRoute: ResourcesRoute,
+  SilentCheckSsoRoute: SilentCheckSsoRoute,
   TermsOfUseRoute: TermsOfUseRoute,
   AboutIndexRoute: AboutIndexRoute,
   HelpAndSupportIndexRoute: HelpAndSupportIndexRoute,

--- a/src/routes/projects/route.tsx
+++ b/src/routes/projects/route.tsx
@@ -3,24 +3,26 @@ import { AppSidebar } from "@/components/dashboard/app-sidebar";
 import { SidebarSkeleton } from "@/components/sidebar-skeleton";
 import { useUser } from "@/hooks/use-user";
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
+import { AuthContext } from "@/providers/auth-context";
 
-import { useEffect } from "react";
+import { useContext, useEffect } from "react";
 
 export const Route = createFileRoute("/projects")({
 	component: DashboardLayout,
 });
 
 function DashboardLayout() {
-	const { data: user, isLoading } = useUser();
+	const { isAuthenticated, loading: authLoading } = useContext(AuthContext);
+	const { data: user, isLoading: userLoading } = useUser(isAuthenticated);
 	const navigate = useNavigate();
 
 	useEffect(() => {
-		if (!isLoading && !user) {
+		if (!authLoading && !isAuthenticated) {
 			navigate({ to: "/" });
 		}
-	}, [user, isLoading, navigate]);
+	}, [authLoading, isAuthenticated, navigate]);
 
-	if (isLoading) {
+	if (authLoading || (isAuthenticated && userLoading)) {
 		return (
 			<SidebarProvider>
 				<SidebarSkeleton />

--- a/src/routes/silent-check-sso.tsx
+++ b/src/routes/silent-check-sso.tsx
@@ -1,0 +1,12 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { useEffect } from "react";
+
+export const Route = createFileRoute("/silent-check-sso")({
+	component: SilentCheckSso,
+});
+
+function SilentCheckSso() {
+	useEffect(() => {
+		window.parent.postMessage(window.location.href, window.location.origin);
+	}, []);
+}


### PR DESCRIPTION
- fix nav bar briefly showing the "Logout" button (and the dashboard link) before the auth check finished loading, regardless of actual login state
- gate the /me query behind isAuthenticated so it no longer fires before the user is logged in
- wait for auth loading to finish before redirecting away from the dashboard, fixing a brief bounce to "/" on page load
- add silent-check-sso.html and set silentCheckSsoRedirectUri so keycloaks silent SSO check has a target page instead of failing